### PR TITLE
fix: append the apikey to the url

### DIFF
--- a/src/lib/utilities.ts
+++ b/src/lib/utilities.ts
@@ -48,6 +48,7 @@ const url = (params: Parameters): string => {
     }
 
     if (queryString) {
+      queryString = queryString.slice(0, -1);
       url += '?' + queryString;
     }
   }
@@ -58,9 +59,7 @@ const url = (params: Parameters): string => {
     url += '&'
   }
 
-  queryString += `apikey=${apikey}`;
-
-  url += queryString;
+  url += `apikey=${apikey}`;
 
   return url;
 }


### PR DESCRIPTION
Previously the apikey was attached to the queryString and the queryString to the url.
In case of parameters, this resulted in duplicating the parameters.
Now the apikey is attached at the end of the url directly.